### PR TITLE
adding couchpy query server support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM quay.io/aptible/ubuntu:14.04
 
 RUN apt-get install -y couchdb curl
+RUN apt-get install -y python2.7 python-pip python-dateutil
+RUN pip install couchdb
 RUN mkdir -p /var/run/couchdb
 
 ADD templates/etc/couchdb /var/lib/couchdb

--- a/templates/etc/couchdb/local.ini
+++ b/templates/etc/couchdb/local.ini
@@ -1,3 +1,7 @@
 [httpd]
 port = 5984
 bind_address = 0.0.0.0
+
+[query_servers]
+javascript = /usr/bin/couchjs /usr/share/couchdb/server/main.js
+python=/usr/local/bin/couchpy


### PR DESCRIPTION
This adds support for couchpy query server in addition to default javascript one.

Note that couchpy is installed by pip, not apt, because we experienced some issues running couchpy from ubuntu python-couchdb package, which is different from latest version installed by pip.