### PR TITLE
Add --dump and --restore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM quay.io/aptible/ubuntu:14.04
 ENV DATA_DIRECTORY /var/db
 RUN apt-get update && apt-get install -y couchdb curl && \
     rm -rf /var/lib/apt/lists/*
+
+# Note that python-couchdb is used for its `couchdb-dump` and `couchdb-load`
+# utilities.
 RUN apt-get update && \
-    apt-get install -y python2.7 python-pip python-dateutil && \
+    apt-get install -y python2.7 python-pip python-dateutil python-couchdb && \
     rm -rf /var/lib/apt/lists/*
 RUN pip install couchdb
 RUN mkdir -p /var/run/couchdb
@@ -27,4 +30,5 @@ RUN bats /tmp/test
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 5984
 
+ADD utilities.sh /usr/bin/
 ENTRYPOINT ["run-database.sh"]

--- a/run-database.sh
+++ b/run-database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
 if [[ "$1" == "--initialize" ]]; then
   # Move the config overrides file to the data volume so it persists.
   # The Dockerfile already created a symlink so that couchdb will pick it up.
@@ -15,7 +17,50 @@ if [[ "$1" == "--initialize" ]]; then
     curl -sX PUT "$username":"$PASSPHRASE"@localhost:5984/_config/couch_httpd_auth/require_valid_user -d '"true"'
   } > /dev/null
   kill $(cat /var/run/couchdb/couchdb.pid)
-  exit
-fi
 
-couchdb
+elif [[ "$1" == "--client" ]]; then
+  echo "This image does not support the --client option. Use curl instead." && exit 1
+
+elif [[ "$1" == "--dump" ]]; then
+  [ -z "$2" ] && echo "docker run aptible/couchdb --dump couchdb://... > dump.couch" && exit
+  parse_url "$2"
+  # For some reason, the output of `couchdb-dump` terminates lines with \r\r\n
+  # and `couchdb-load` can't handle it. Pipe to `tr` to remove all \r.
+  #
+  # `couchdb-dump` outputs "Dumping document..." to stderr, and `docker run -t`
+  # blurs the distinction between stdout and stderr, so it's important to not
+  # use `-t` for invoking this.
+  #
+  # Note that these `couchdb-dump` and `couchdb-load` tools are part of the
+  # python-couchdb package installed with apt-get in the Dockerfile.
+  # CouchDB does not have usable dump/restore capabilities built in.
+  couchdb-dump "http://"$user":"$password"@"$host":"${port:-5984}"/"$database"" 2>/dev/null | tr -d '\r'
+
+elif [[ "$1" == "--restore" ]]; then
+  [ -z "$2" ] && echo "docker run -i aptible/couchdb --restore couchdb://... < dump.couch" && exit
+  parse_url "$2"
+  couchdb-load "http://"$user":"$password"@"$host":"${port:-5984}"/"$database""
+
+elif [[ "$1" == "--readonly" ]]; then
+  # CouchDB doesn't have a daemon-wide read-only mode. Instead, while the
+  # server is running, install a "design document" on a given database which
+  # rejects update. Example of installing this design document:
+  #
+  # curl -X PUT http://user:pass@host:5984/db/_design/readonly --data '{"validate_doc_update":"function(){}"}'
+  #
+  # To remove read-only mode, the design document should be deleted.
+  # Deleting it requires the document's revision id, which can be found by
+  # issuing a GET or by taking note when the initial PUT returns.
+  #
+  # This is documented here:
+  # design documents in general: http://couchdb-13.readthedocs.org/en/latest/api/design/
+  # validate_doc_update: http://docs.couchdb.org/en/latest/couchapp/ddocs.html#vdufun
+  #
+  # With all of that said, leaving off read-only mode for now.
+  echo "This image does not support read-only mode. Starting database normally."
+  couchdb
+
+else
+  couchdb
+
+fi

--- a/utilities.sh
+++ b/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}


### PR DESCRIPTION
This PR adds dump and restore capabilities to the CouchDB image. The dump and restore are provided by the `python-couchdb` package's `couchdb-dump` and `couchdb-load` tools [1]. The reason for using the third party tools is that, while CouchDB offers a facility for dumping data and bulk importing data, the dump file format is not compatible with the bulk import [2, 3].

CouchDB also does not support read-only mode in a way that's easily compatible with the Aptible standardized database image spec. I've outlined the steps for setting and removing read-only mode in comments in `run-database.sh`, but the functionality is omitted for the time being.

The closest thing to a CouchDB client or CLI is simply `curl`, so the `--client` option is unsupported.

[1] https://github.com/djc/couchdb-python
[2] http://gotofritz.tumblr.com/post/3804683243/dumping-a-couchdb-database-to-a-file
[3] http://stackoverflow.com/questions/11639534/couchdb-dump-to-file-and-load-from-file